### PR TITLE
Add buildpacks

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/mcollina/heroku-buildpack-imagemagick
+https://github.com/heroku/heroku-buildpack-ruby


### PR DESCRIPTION
This fixes the previous error uploading images:

```
Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: Command ("mogrify -brightness-contrast -30x0 /tmp/mini_magick20140321-2-166shmo.png") failed: {:status_code=>1, :output=>"mogrify: unrecognized option `-brightness-contrast' @ mogrify.c/MogrifyImageCommand/4276.\n"}
```

The error is due to an older version of imagemagick being present on heroku. This buildpack upgrades it ;)

You'll also need to run this on production:

```
heroku config:set BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi
```
