### PR TITLE
Add support for published timeslots

### DIFF
--- a/app/admin/timeslot.rb
+++ b/app/admin/timeslot.rb
@@ -13,6 +13,7 @@ ActiveAdmin.register Timeslot do
       f.input :description, input_html: {
         rows: 3
       }
+      f.input :published
     end
 
     f.inputs "Details" do

--- a/app/models/timeslot.rb
+++ b/app/models/timeslot.rb
@@ -4,10 +4,11 @@ class Timeslot < ActiveRecord::Base
 
   default_scope { order('start ASC') }
   scope :upcoming, -> {
-    where("start >= ?", Date.today.beginning_of_year)
+    where("start >= ? AND published = ?", Date.today.beginning_of_year, true)
   }
   scope :this_year, -> {
-    where(start: (Date.today.beginning_of_year..Date.today.end_of_year))
+    where(start: (Date.today.beginning_of_year..Date.today.end_of_year),
+          published: true)
   }
 
   just_define_datetime_picker :start

--- a/db/migrate/20150411024723_add_published_to_timeslot.rb
+++ b/db/migrate/20150411024723_add_published_to_timeslot.rb
@@ -1,0 +1,5 @@
+class AddPublishedToTimeslot < ActiveRecord::Migration
+  def change
+    add_column :timeslots, :published, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140405003038) do
+ActiveRecord::Schema.define(version: 20150411024723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 20140405003038) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "venue_id"
+    t.boolean  "published"
   end
 
   create_table "venues", force: true do |t|


### PR DESCRIPTION
We'll want to go ahead and set everything to published immediately after deploy. 
```
Timeslot.all.each { |t| t.published = true; t.save }
```

Fixes #4 